### PR TITLE
Fix: Configure build to output client to dist/public and server to di…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "build": "npx vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     },
   },
   root: path.resolve(import.meta.dirname, "client"),
+  base: "./", // Ensure assets are linked relatively for file:/// protocol
   build: {
     outDir: "../dist/public", // Correctly relative to the 'root' option
     emptyOutDir: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   },
   root: path.resolve(import.meta.dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: "../dist/public", // Correctly relative to the 'root' option
     emptyOutDir: true,
   },
 });


### PR DESCRIPTION
…st/server

- Modified vite.config.ts to set build.outDir to '../dist/public' relative to the 'client' root, ensuring frontend assets are placed in PROJECT_ROOT/dist/public.
- Updated package.json build script to use npx for vite and esbuild to ensure local versions are used.
- Ensured esbuild outputs server code to PROJECT_ROOT/dist/server, preventing conflict with frontend build.
- Updated package.json start script to point to the new server path in dist/server/index.js.